### PR TITLE
Added ability to specify input columns to split on

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ values are:
 1. test_percent = 0.1; Portion of data to place in test set. Must be between 0 and 1.
 1. num_iterations = 1000; Number of iterations to randomly check in each split. It is not recommended to decrease this 
 number below 1000.
+1. splits_cols = None; Specific columns to include in the data split calculation. None will include all columns except id. A list of column names will result in only those columns being considered. Use this to exclude non-numeric columns from the calculation.
 1. save_output = True; If True then save the resulting data split and plots to file. Set to False to avoid saving 
 anything to file.
 1. output_path = './'; Set the path to the directory to save the results and plot if save_output is True.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "optimal-data-splitter"
-version = "0.1.2"
+version = "0.1.3"
 description = "Data splitting package"
 authors = ["Matthew Rockwood"]
 license = "MIT"


### PR DESCRIPTION
Added a new config options "split_cols" that can be used to only include specific columns in the data splitting calculation. This is helpful for excluding non-numeric columns in the input data, or for removing specific numeric columns that may be heavily biasing the split in an unhelpful manner.

Updated README and pyproject.toml for release.